### PR TITLE
fixed race conditions

### DIFF
--- a/firmware-arduino/src/Audio.cpp
+++ b/firmware-arduino/src/Audio.cpp
@@ -288,7 +288,7 @@ void webSocketEvent(WStype_t type, uint8_t *payload, size_t length)
                 // Check if volume_control is included in the message
                 if (doc.containsKey("volume_control")) {
                     int newVolume = doc["volume_control"].as<int>();
-                    volume.setVolume(newVolume / 100.0f * 1.4f);
+                    volume.setVolume(newVolume / 100.0f);
                 }
 
                 scheduleListeningRestart = true;

--- a/firmware-arduino/src/Audio.cpp
+++ b/firmware-arduino/src/Audio.cpp
@@ -59,7 +59,7 @@ VolumeStream volume(i2s); //access from audioStreamTask only
 QueueStream<uint8_t> queue(audioBuffer); //access from audioStreamTask only
 StreamCopy copier(volume, queue);
 AudioInfo info(SAMPLE_RATE, CHANNELS, BITS_PER_SAMPLE);
-volatile bool outputFlushScheduled = false;
+volatile bool i2sOutputFlushScheduled = false;
 
 unsigned long getSpeakingDuration() {
     if (deviceState == SPEAKING && speakingStartTime > 0) {
@@ -91,7 +91,7 @@ void transitionToListening() {
     Serial.println("Transitioning to listening mode");
 
     i2sInputFlushScheduled = true;
-    outputFlushScheduled = true;
+    i2sOutputFlushScheduled = true;
 
     Serial.println("Transitioned to listening mode");
 
@@ -139,8 +139,8 @@ void audioStreamTask(void *parameter) {
     volume.begin(vcfg);
 
     while (1) {
-        if ( outputFlushScheduled) {
-            outputFlushScheduled = false;
+        if ( i2sOutputFlushScheduled) {
+            i2sOutputFlushScheduled = false;
             i2s.flush();
             volume.flush();
             queue.flush();

--- a/firmware-arduino/src/Audio.h
+++ b/firmware-arduino/src/Audio.h
@@ -13,7 +13,7 @@ extern TaskHandle_t speakerTaskHandle;
 extern TaskHandle_t micTaskHandle;
 extern TaskHandle_t networkTaskHandle;
 
-extern bool scheduleListeningRestart;
+extern volatile bool scheduleListeningRestart;
 extern unsigned long scheduledTime;
 extern unsigned long speakingStartTime;
 
@@ -31,10 +31,12 @@ extern VolumeStream volume;
 extern QueueStream<uint8_t> queue;
 extern StreamCopy copier;
 extern AudioInfo info;
+extern volatile bool outputFlushScheduled;
 
 // AUDIO INPUT
 extern I2SStream i2sInput;
 extern StreamCopy micToWsCopier;
+extern volatile bool i2sInputFlushScheduled;
 
 // WEBSOCKET
 void webSocketEvent(WStype_t type, uint8_t *payload, size_t length);

--- a/firmware-arduino/src/Audio.h
+++ b/firmware-arduino/src/Audio.h
@@ -31,7 +31,7 @@ extern VolumeStream volume;
 extern QueueStream<uint8_t> queue;
 extern StreamCopy copier;
 extern AudioInfo info;
-extern volatile bool outputFlushScheduled;
+extern volatile bool i2sOutputFlushScheduled;
 
 // AUDIO INPUT
 extern I2SStream i2sInput;

--- a/firmware-arduino/src/Config.cpp
+++ b/firmware-arduino/src/Config.cpp
@@ -59,7 +59,7 @@ const uint16_t backend_port = 3000;
 #endif
 
 String authTokenGlobal;
-DeviceState deviceState = IDLE;
+volatile DeviceState deviceState = IDLE;
 
 // I2S and Audio parameters
 const uint32_t SAMPLE_RATE = 24000;

--- a/firmware-arduino/src/Config.h
+++ b/firmware-arduino/src/Config.h
@@ -44,10 +44,11 @@ enum DeviceState
     PROCESSING,
     WAITING,
     OTA,
-    FACTORY_RESET
+    FACTORY_RESET,
+    SLEEP
 };
 
-extern DeviceState deviceState;
+extern volatile DeviceState deviceState;
 
 // WiFi credentials
 extern const char *EAP_IDENTITY;

--- a/firmware-arduino/src/main.cpp
+++ b/firmware-arduino/src/main.cpp
@@ -31,7 +31,7 @@ void enterSleep()
     // First, change device state to prevent any new data processing
     deviceState = SLEEP;
     scheduleListeningRestart = false;
-    outputFlushScheduled = true;
+    i2sOutputFlushScheduled = true;
     i2sInputFlushScheduled = true;
     vTaskDelay(10);  //let all tasks accept state
 
@@ -42,7 +42,7 @@ void enterSleep()
     i2s_stop(I2S_PORT_OUT);
 
     // Clear any remaining audio in buffer
-    outputFlushScheduled = true;
+    i2sOutputFlushScheduled = true;
 
     // Properly disconnect WebSocket and wait for it to complete
     if (webSocket.isConnected()) {

--- a/firmware-arduino/src/main.cpp
+++ b/firmware-arduino/src/main.cpp
@@ -20,27 +20,38 @@ AsyncWebServer webServer(80);
 WIFIMANAGER WifiManager;
 esp_err_t getErr = ESP_OK;
 
+// Main Thread -> onButtonLongPressUpEventCb -> enterSleep()
+// Main Thread -> onButtonDoubleClickCb -> enterSleep()
+// Touch Task -> touchTask -> enterSleep()
+// Main Thread -> loop() (inactivity timeout) -> enterSleep()
 void enterSleep()
 {
     Serial.println("Going to sleep...");
     
     // First, change device state to prevent any new data processing
-    deviceState = IDLE;
+    deviceState = SLEEP;
+    scheduleListeningRestart = false;
+    outputFlushScheduled = true;
+    i2sInputFlushScheduled = true;
+    vTaskDelay(10);  //let all tasks accept state
+
+    xSemaphoreTake(wsMutex, portMAX_DELAY);
 
     // Stop audio tasks first
     i2s_stop(I2S_PORT_IN);
     i2s_stop(I2S_PORT_OUT);
 
     // Clear any remaining audio in buffer
-    audioBuffer.reset();
-    
+    outputFlushScheduled = true;
+
     // Properly disconnect WebSocket and wait for it to complete
     if (webSocket.isConnected()) {
         webSocket.disconnect();
         // Give some time for the disconnect to process
-        delay(100);
     }
-    
+    xSemaphoreGive(wsMutex);
+    delay(100);
+
     // Stop all tasks that might be using I2S or other peripherals
     i2s_driver_uninstall(I2S_PORT_IN);
     i2s_driver_uninstall(I2S_PORT_OUT);
@@ -58,6 +69,7 @@ void enterSleep()
     #endif
 
     esp_deep_sleep_start();
+    delay(1000);
 }
 
 void printOutESP32Error(esp_err_t err)

--- a/firmware-arduino/src/main.cpp
+++ b/firmware-arduino/src/main.cpp
@@ -41,9 +41,6 @@ void enterSleep()
     i2s_stop(I2S_PORT_IN);
     i2s_stop(I2S_PORT_OUT);
 
-    // Clear any remaining audio in buffer
-    i2sOutputFlushScheduled = true;
-
     // Properly disconnect WebSocket and wait for it to complete
     if (webSocket.isConnected()) {
         webSocket.disconnect();


### PR DESCRIPTION
Issue:
- Periodic disconnections and crashes caused by memory corruption.
- websocket is accessed from multiple threads without synchronization.
- Some streams are being reset concurrently from different threads.

Fix (in this PR):
- Resolved race conditions related to websocket and stream access.
 - Wrapped websocket->loop() with wsMutex to ensure thread safety.  Methods invoked inside the socketEvent callback are always called from within loop() and therefore do not require additional locking.
- audioBuffer (RTOS queue) access follows a single-producer, single-consumer pattern, which allows safe parallel read/write operations without additional synchronization.

