### PR TITLE
feat(fastapi): add MiniMax LLM provider

### DIFF
--- a/server/fastapi/README.md
+++ b/server/fastapi/README.md
@@ -24,6 +24,7 @@ To keep onboarding straightforward, the classic FastAPI route is centered around
 - `claude`
 - `gemini`
 - `grok`
+- `minimax`
 
 ### STT
 
@@ -203,6 +204,7 @@ The current simple provider map is:
 - `claude` LLM: `ANTHROPIC_API_KEY`
 - `gemini` LLM: `GEMINI_API_KEY`
 - `grok` LLM: `XAI_API_KEY`
+- `minimax` LLM: `MINIMAX_API_KEY`
 - `deepgram` STT: `DEEPGRAM_API_KEY`
 - `whisper` STT: no external API key required
 - `elevenlabs` TTS: `ELEVENLABS_API_KEY`
@@ -220,6 +222,7 @@ Each supported provider now has its own module file so the layout is easy to und
 - `/Users/akashdeepdeb/Desktop/Projects/ElatoAI/server/fastapi/models/llm/anthropic.py`
 - `/Users/akashdeepdeb/Desktop/Projects/ElatoAI/server/fastapi/models/llm/gemini.py`
 - `/Users/akashdeepdeb/Desktop/Projects/ElatoAI/server/fastapi/models/llm/grok.py`
+- `/Users/akashdeepdeb/Desktop/Projects/ElatoAI/server/fastapi/models/llm/minimax.py`
 - `/Users/akashdeepdeb/Desktop/Projects/ElatoAI/server/fastapi/models/stt/deepgram.py`
 - `/Users/akashdeepdeb/Desktop/Projects/ElatoAI/server/fastapi/models/stt/whisper.py`
 - `/Users/akashdeepdeb/Desktop/Projects/ElatoAI/server/fastapi/models/tts/elevenlabs.py`
@@ -260,6 +263,17 @@ CLASSIC_STT_PROVIDER=deepgram
 CLASSIC_LLM_PROVIDER=gemini
 CLASSIC_TTS_PROVIDER=openai
 ```
+
+### Deepgram + MiniMax + ElevenLabs
+
+```env
+CLASSIC_STT_PROVIDER=deepgram
+CLASSIC_LLM_PROVIDER=minimax
+CLASSIC_TTS_PROVIDER=elevenlabs
+```
+
+MiniMax uses an OpenAI-compatible chat API, so only `MINIMAX_API_KEY` is
+required. The default model is `MiniMax-M3`.
 
 ## Unified Experience Across Elato
 

--- a/server/fastapi/env.example
+++ b/server/fastapi/env.example
@@ -3,9 +3,12 @@ OPENAI_API_KEY=your_openai_api_key
 ANTHROPIC_API_KEY=your_anthropic_api_key
 GEMINI_API_KEY=your_gemini_api_key
 XAI_API_KEY=your_xai_api_key
+MINIMAX_API_KEY=your_minimax_api_key
 ELEVENLABS_API_KEY=your_elevenlabs_api_key
 CARTESIA_API_KEY=your_cartesia_api_key
 # Whisper STT in Pipecat is local/offline, so it does not require an API key.
+# MiniMax is OpenAI-compatible. Override the base URL for the mainland China
+# endpoint if needed: MINIMAX_BASE_URL=https://api.minimaxi.com/v1
 
 # Classic route providers
 CURRENT_VOICE_ROUTE=classic

--- a/server/fastapi/models/llm/minimax.py
+++ b/server/fastapi/models/llm/minimax.py
@@ -1,0 +1,42 @@
+"""MiniMax LLM provider.
+
+MiniMax exposes an OpenAI-compatible chat-completions API, so we reuse
+Pipecat's ``OpenAILLMService`` and only point it at the MiniMax base URL.
+This mirrors how Pipecat wires other OpenAI-compatible vendors (Grok, Groq,
+DeepSeek, ...) and keeps the provider module thin.
+
+Docs: https://platform.minimax.io/docs/api-reference/text-openai-api
+"""
+
+from __future__ import annotations
+
+import os
+
+from pipecat.services.openai.llm import OpenAILLMService
+
+# Overseas (default) OpenAI-compatible endpoint. Mainland China users can set
+# MINIMAX_BASE_URL to https://api.minimaxi.com/v1 instead.
+DEFAULT_BASE_URL = "https://api.minimax.io/v1"
+DEFAULT_MODEL = "MiniMax-M3"
+
+
+def create_service(**kwargs):
+    """Create an OpenAI-compatible Pipecat LLM service backed by MiniMax."""
+    api_key = kwargs.get("api_key") or os.getenv("MINIMAX_API_KEY")
+    base_url = kwargs.get("base_url") or os.getenv("MINIMAX_BASE_URL") or DEFAULT_BASE_URL
+    model = kwargs.get("model") or DEFAULT_MODEL
+
+    settings_kwargs: dict[str, object] = {"model": model}
+    if kwargs.get("system_instruction") is not None:
+        settings_kwargs["system_instruction"] = kwargs["system_instruction"]
+
+    # MiniMax requires temperature in the (0.0, 1.0] range and rejects 0, so we
+    # default to 1.0 instead of leaving it unset / passing 0.
+    temperature = kwargs.get("temperature")
+    settings_kwargs["temperature"] = 1.0 if temperature is None else temperature
+
+    return OpenAILLMService(
+        api_key=api_key,
+        base_url=base_url,
+        settings=OpenAILLMService.Settings(**settings_kwargs),
+    )

--- a/server/fastapi/models/providers.py
+++ b/server/fastapi/models/providers.py
@@ -52,6 +52,13 @@ PROVIDER_SPECS: dict[ProviderCategory, dict[str, ProviderSpec]] = {
             env=("XAI_API_KEY",),
             description="xAI Grok via Pipecat.",
         ),
+        "minimax": ProviderSpec(
+            name="minimax",
+            category="llm",
+            module="models.llm.minimax",
+            env=("MINIMAX_API_KEY",),
+            description="MiniMax (OpenAI-compatible) chat models such as MiniMax-M3.",
+        ),
     },
     "stt": {
         "deepgram": ProviderSpec(


### PR DESCRIPTION
## Summary

Adds **MiniMax** as a new LLM provider for the `server/fastapi` classic STT → LLM → TTS voice pipeline.

MiniMax exposes an OpenAI-compatible chat-completions API, so the provider reuses Pipecat's `OpenAILLMService` pointed at the MiniMax base URL (`https://api.minimax.io/v1`). This is the same pattern Pipecat itself uses to wire other OpenAI-compatible vendors (Grok, Groq, DeepSeek), so it fits the existing provider architecture cleanly and needs no new dependencies.

## Changes

- Add `models/llm/minimax.py` — thin provider module, default model `MiniMax-M3`
- Register `"minimax"` in the LLM provider catalog in `models/providers.py` (requires `MINIMAX_API_KEY`); it now shows up in the `/providers` endpoint and is validated at startup like the other providers
- Document `MINIMAX_API_KEY` (and the optional `MINIMAX_BASE_URL` override for the mainland-China endpoint) in `env.example`
- Update the FastAPI `README.md` (provider list, required keys, module list, example stack)

## Usage

```env
CLASSIC_LLM_PROVIDER=minimax
MINIMAX_API_KEY=your_minimax_api_key
```

The default model is `MiniMax-M3`. Override with `MINIMAX_BASE_URL` for the mainland-China endpoint (`https://api.minimaxi.com/v1`).

## Notes

- Temperature defaults to `1.0` because MiniMax requires `temperature` in `(0.0, 1.0]` and rejects `0`.
- The module imports `OpenAILLMService` directly (rather than going through the generic autodiscovery helper) so it works on the project's declared minimum Python 3.10 — Pipecat has no native MiniMax LLM service, only a TTS one, so this is the idiomatic wiring.

## Testing

- Verified the full path `create_llm_service("minimax", ...)` resolves to an `OpenAILLMService` with the correct base URL, default model `MiniMax-M3`, and temperature `1.0`; model/base URL/temperature overrides are honored and missing-key validation fails early.
- Confirmed against the live MiniMax OpenAI-compatible endpoint that the `MiniMax-M3` model id and auth are accepted.
- `ruff check`/`ruff format` clean on the new module.