### PR TITLE
feat: add Atlas Cloud LLM provider

### DIFF
--- a/server/fastapi/env.example
+++ b/server/fastapi/env.example
@@ -1,5 +1,8 @@
 DEEPGRAM_API_KEY=your_deepgram_api_key
 OPENAI_API_KEY=your_openai_api_key
+ATLASCLOUD_API_KEY=your_atlascloud_api_key
+ATLASCLOUD_BASE_URL=https://api.atlascloud.ai/v1
+ATLASCLOUD_MODEL=deepseek-ai/deepseek-v4-pro
 ANTHROPIC_API_KEY=your_anthropic_api_key
 GEMINI_API_KEY=your_gemini_api_key
 XAI_API_KEY=your_xai_api_key

--- a/server/fastapi/models/llm/atlascloud.py
+++ b/server/fastapi/models/llm/atlascloud.py
@@ -1,0 +1,28 @@
+"""Atlas Cloud OpenAI-compatible LLM provider."""
+
+from __future__ import annotations
+
+import os
+
+from pipecat.services.openai.llm import OpenAILLMService
+
+DEFAULT_BASE_URL = "https://api.atlascloud.ai/v1"
+DEFAULT_MODEL = "deepseek-ai/deepseek-v4-pro"
+
+
+def create_service(**kwargs):
+    api_key = kwargs.pop("api_key", None) or os.getenv("ATLASCLOUD_API_KEY")
+    base_url = kwargs.pop("base_url", None) or os.getenv("ATLASCLOUD_BASE_URL", DEFAULT_BASE_URL)
+    model = kwargs.pop("model", None) or os.getenv("ATLASCLOUD_MODEL", DEFAULT_MODEL)
+    system_instruction = kwargs.pop("system_instruction", None)
+    settings = kwargs.pop("settings", None) or OpenAILLMService.Settings(
+        model=model,
+        system_instruction=system_instruction,
+    )
+
+    return OpenAILLMService(
+        api_key=api_key,
+        base_url=base_url,
+        settings=settings,
+        **kwargs,
+    )

--- a/server/fastapi/models/providers.py
+++ b/server/fastapi/models/providers.py
@@ -6,7 +6,6 @@ import os
 from dataclasses import asdict, dataclass
 from typing import Literal
 
-
 ProviderCategory = Literal["llm", "stt", "tts"]
 
 
@@ -28,6 +27,14 @@ PROVIDER_SPECS: dict[ProviderCategory, dict[str, ProviderSpec]] = {
             module="models.llm.openai",
             env=("OPENAI_API_KEY",),
             description="OpenAI chat-completions compatible LLM.",
+        ),
+        "atlascloud": ProviderSpec(
+            name="atlascloud",
+            category="llm",
+            module="models.llm.atlascloud",
+            env=("ATLASCLOUD_API_KEY",),
+            aliases=("atlas_cloud",),
+            description="Atlas Cloud via its OpenAI-compatible chat-completions API.",
         ),
         "claude": ProviderSpec(
             name="claude",
@@ -117,7 +124,9 @@ def get_provider_spec(category: ProviderCategory, provider_name: str) -> Provide
         if normalized == key or normalized in spec.aliases:
             return spec
     available = ", ".join(sorted(PROVIDER_SPECS[category]))
-    raise ValueError(f"Unknown {category} provider '{provider_name}'. Available providers: {available}")
+    raise ValueError(
+        f"Unknown {category} provider '{provider_name}'. Available providers: {available}"
+    )
 
 
 def validate_provider_env(category: ProviderCategory, provider_name: str) -> None:

--- a/server/fastapi/tests/test_atlascloud_provider.py
+++ b/server/fastapi/tests/test_atlascloud_provider.py
@@ -1,0 +1,45 @@
+import os
+import unittest
+from unittest.mock import patch
+
+from models.llm import atlascloud
+from models.providers import get_provider_registry, get_provider_spec, validate_provider_env
+
+
+class AtlasCloudProviderTest(unittest.TestCase):
+    def test_registry_supports_canonical_name_and_alias(self):
+        registry = get_provider_registry("llm")
+
+        self.assertEqual(registry["atlascloud"], "models.llm.atlascloud")
+        self.assertEqual(registry["atlas_cloud"], "models.llm.atlascloud")
+        self.assertEqual(get_provider_spec("llm", "Atlas_Cloud").name, "atlascloud")
+
+    def test_environment_validation_requires_atlascloud_key(self):
+        with patch.dict(os.environ, {}, clear=True):
+            with self.assertRaisesRegex(RuntimeError, "ATLASCLOUD_API_KEY"):
+                validate_provider_env("llm", "atlascloud")
+
+        with patch.dict(os.environ, {"ATLASCLOUD_API_KEY": "test-key"}, clear=True):
+            validate_provider_env("llm", "atlascloud")
+
+    def test_factory_uses_openai_compatible_defaults(self):
+        with (
+            patch.dict(os.environ, {"ATLASCLOUD_API_KEY": "test-key"}, clear=True),
+            patch.object(atlascloud, "OpenAILLMService") as service,
+        ):
+            service.Settings.return_value = "settings"
+            atlascloud.create_service(system_instruction="Be concise")
+
+        service.Settings.assert_called_once_with(
+            model="deepseek-ai/deepseek-v4-pro",
+            system_instruction="Be concise",
+        )
+        service.assert_called_once_with(
+            api_key="test-key",
+            base_url="https://api.atlascloud.ai/v1",
+            settings="settings",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- register Atlas Cloud as a first-class classic LLM provider, including an `atlas_cloud` alias
- use Pipecat's existing OpenAI-compatible service with Atlas Cloud API key, base URL, and model configuration
- preserve the classic voice pipeline system instruction through Pipecat runtime settings
- add provider registry, environment validation, and factory argument tests

## Validation
- `PYTHONPATH=server/fastapi python -m unittest discover -s server/fastapi/tests -v` (3 passed)
- `ruff check` on changed Python files
- `ruff format --check` on changed Python files
- `python -m compileall -q server/fastapi/models server/fastapi/tests`
- `git diff --check`
- verified `deepseek-ai/deepseek-v4-pro` against the public Atlas Cloud model catalog

## Documentation
No README changes. `server/fastapi/env.example` only adds optional technical configuration; no sponsor, logo, credits, or partner promotion.